### PR TITLE
Fixed wrong assignment of `FLEXCAN_FDCBT_PROPSEG`

### DIFF
--- a/src/ACAN_T4FD.cpp
+++ b/src/ACAN_T4FD.cpp
@@ -275,7 +275,7 @@ uint32_t ACAN_T4::beginFD (const ACAN_T4FD_Settings & inSettings,
     ;
   //---------- Data Can bit timing (FDCBT, §44.6.2.26, page 2813)
     FLEXCAN_FDCBT (mFlexcanBaseAddress) =
-      FLEXCAN_FDCBT_PROPSEG (inSettings.mDataPropagationSegment - 1) |
+      FLEXCAN_FDCBT_PROPSEG (inSettings.mDataPropagationSegment) |
       FLEXCAN_FDCBT_RJW (inSettings.mDataRJW - 1) |
       FLEXCAN_FDCBT_PSEG1 (inSettings.mDataPhaseSegment1 - 1) |
       FLEXCAN_FDCBT_PSEG2 (inSettings.mDataPhaseSegment2 - 1) |


### PR DESCRIPTION
According to the processor manual, the prop seg timeout is calculated from the `FDCBT_PROPSEG` value by multiplying it with the `sclock` directly. The value is not increased by one beforehand¹.

In the reference manual the calculation of the segment time is stated as: 
```Propagation Segment Time = FPROPSEG × Time-Quanta```

This is indeed different to the programming of the CAN2.0 Interface (`CBT_PROPSEG`)², where the calculation is:
```Propagation Segment Time = (EPROPSEG + 1) × Time-Quanta.```

Without this commit the actual frequency, with which the `BRS` packages are send, is to high. 

Sources:
¹: i.MX RT1060 Processor Reference Manual, Rev. 2, 12/2019 / Chapter 45.6.2.22.4 / Page 2701
²: i.MX RT1060 Processor Reference Manual, Rev. 2, 12/2019 / Chapter 45.6.2.19.4 / Page 2695